### PR TITLE
Service port forwarding and is_connected() periodically during traffic

### DIFF
--- a/lib/poller.rs
+++ b/lib/poller.rs
@@ -10,6 +10,7 @@ pub struct Poller<'poller> {
     poller: polling::Poller,
     events: polling::Events,
     timeout: Duration,
+    last_periodic_tick: coarsetime::Instant,
     vm_fd: BorrowedFd<'poller>,
     host_fd: BorrowedFd<'poller>,
     control_fd: Option<BorrowedFd<'poller>>,
@@ -37,6 +38,7 @@ impl Poller<'_> {
             poller,
             events: polling::Events::new(),
             timeout,
+            last_periodic_tick: coarsetime::Instant::recent(),
             vm_fd: unsafe { BorrowedFd::borrow_raw(vm_fd) },
             host_fd: unsafe { BorrowedFd::borrow_raw(host_fd) },
             control_fd: control_fd.map(|fd| unsafe { BorrowedFd::borrow_raw(fd) }),
@@ -92,6 +94,16 @@ impl Poller<'_> {
             .iter()
             .any(|ev| ev.key == Into::<usize>::into(EventKey::Interrupt));
         Ok((vm_readable, host_readable, interrupt))
+    }
+
+    pub fn periodic_tick_due(&mut self) -> bool {
+        let due = self.last_periodic_tick.elapsed_since_recent() >= self.timeout.into();
+
+        if due {
+            self.last_periodic_tick = coarsetime::Instant::recent();
+        }
+
+        due
     }
 
     pub fn remove_control(&mut self) -> Result<()> {

--- a/lib/proxy/mod.rs
+++ b/lib/proxy/mod.rs
@@ -108,11 +108,6 @@ impl Proxy<'_> {
         loop {
             let (vm_readable, host_readable, interrupt) = self.poller.wait()?;
 
-            // kqueue does not report peer disconnects for Unix datagram sockets.
-            if !self.vm.is_connected()? {
-                return Ok(());
-            }
-
             // Update coarse time for DHCP snooping and flows
             coarsetime::Instant::update();
 
@@ -133,8 +128,13 @@ impl Proxy<'_> {
                 return Ok(());
             }
 
-            // Timeout
-            if !vm_readable && !host_readable && !interrupt {
+            // Periodic maintenance
+            if self.poller.periodic_tick_due() {
+                // kqueue(2) does not report peer disconnects for Unix datagram sockets
+                if !self.vm.is_connected()? {
+                    return Ok(());
+                }
+
                 self.port_forwarder
                     .tick(&mut self.host, self.dhcp_snooper.lease());
             }


### PR DESCRIPTION
**Problem**

Continuous traffic could prevent periodic port-forwarding maintenance from running.

Conditions like:

* `!vm_readable && !host_readable && !interrupt`
* `self.events.is_empty()`

...only detect an idle poll wake, not whether the timeout interval has elapsed.

Additionally, we run `is_connected()` for each loop cycle, which might be too much.

**Solution**

Track the periodic interval with `coarsetime::Instant` in `Poller` and expose `periodic_tick_due()`.

Port forwarding maintenance and `is_connected()` check now runs when the interval elapses, regardless of poll readiness events.